### PR TITLE
Always Notify a Signal

### DIFF
--- a/rethinkdb_filter_block.py
+++ b/rethinkdb_filter_block.py
@@ -23,9 +23,16 @@ class RethinkDBFilter(RethinkDBBase, EnrichSignals):
             self.logger.debug('Filter is Processing signal: {}'.format(signal))
             # update incoming signals with results of the query
             results = self.execute_with_retry(self._filter, signal)
-            for result in results:
-                out_sig = self.get_output_signal(result, signal)
+            if results:
+                for result in results:
+                    out_sig = self.get_output_signal(result, signal)
+                    notify_list.append(out_sig)
+            else:
+                # always notify a signal. still append empty results to
+                # enriched signals
+                out_sig = self.get_output_signal(results, signal)
                 notify_list.append(out_sig)
+
         self.notify_signals(notify_list)
 
     def _filter(self, signal):

--- a/tests/test_rethinkdb_block.py
+++ b/tests/test_rethinkdb_block.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch, MagicMock
 from nio.signal.base import Signal
 from nio.testing.block_test_case import NIOBlockTestCase
-from ..rethinkdb_base_block import RethinkDBBase
 from ..rethinkdb_changes_block import RethinkDBChanges
 from ..rethinkdb_update_block import RethinkDBUpdate
 
@@ -16,9 +15,9 @@ class TestRethinkDBUpdateBlock(NIOBlockTestCase):
         blk.update_table = MagicMock(return_value={'result': 1})
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
-            mock_rdb.db.return_value.table.return_value.update.return_value.\
-                run.return_value = {"errors": 0}
-            blk.process_signals([Signal({'test': 1})])
+            mock_rdb.db.return_value.table.return_value.filter.return_value.\
+                update.return_value.run.return_value = {"errors": 0}
+            blk.process_signals([Signal({'id': 1, 'test': 1})])
         blk.stop()
         # original input signal and output signal
         self.assert_num_signals_notified(1)


### PR DESCRIPTION
If a filter block comes back with nothing, no signal is notified (and no enriched signal). The expected behavior here with enriched signals would be to always notify the enriched signal, but have the value either be populated or unpopulated based on if results were returned or not. 

Otherwise this is problematic due to the signal being ignored by the router if it is an empty list.