### PR TITLE
Rethink queries use .get() rather than .filter AZZ-1217

### DIFF
--- a/rethinkdb_base_block.py
+++ b/rethinkdb_base_block.py
@@ -31,3 +31,5 @@ class RethinkDBBase(LimitLock, Retry, Block):
 
     def _locked_process_signals(self, signals):
         pass
+
+    # def check_is_primary_key

--- a/rethinkdb_base_block.py
+++ b/rethinkdb_base_block.py
@@ -31,5 +31,3 @@ class RethinkDBBase(LimitLock, Retry, Block):
 
     def _locked_process_signals(self, signals):
         pass
-
-    # def check_is_primary_key

--- a/rethinkdb_delete_block.py
+++ b/rethinkdb_delete_block.py
@@ -39,7 +39,7 @@ class RethinkDBDelete(EnrichSignals, RethinkDBBase):
             # as well as changes. If the delete was successful, 'new_val' will
             # be none in changes.
             results = rdb.db(self.database_name()).table(self.table()).\
-                filter(self.filter(signal)).delete(return_changes=True).\
+                get(self.filter(signal)["id"]).delete(return_changes=True).\
                 run(conn)
 
         if results["deleted"] == 0:

--- a/rethinkdb_delete_block.py
+++ b/rethinkdb_delete_block.py
@@ -39,10 +39,22 @@ class RethinkDBDelete(EnrichSignals, RethinkDBBase):
             # as well as changes. If the delete was successful, 'new_val' will
             # be none in changes.
 
-            # can't just run .get(), need to check if primary key is only filter condition
-            results = rdb.db(self.database_name()).table(self.table()).\
-                filter(self.filter(signal)).delete(return_changes=True).\
-                run(conn)
+            # Query table configuration to get primary key
+            table_config = rdb.db(self.database_name()).table(self.table()).\
+                config()
+            primary_key = table_config["primary_key"]
+            filter_condition = self.filter(signal)
+
+            # Check if filter condition is only primary key, if so, use
+            # .get rather than .filter for better performance
+            if list(filter_condition.keys()) == list(primary_key):
+                results = rdb.db(self.database_name()).table(self.table()). \
+                    get(filter_condition).delete(return_changes=True). \
+                    run(conn)
+            else:
+                results = rdb.db(self.database_name()).table(self.table()).\
+                    filter(self.filter(signal)).delete(return_changes=True).\
+                    run(conn)
 
         if results["deleted"] == 0:
             self.logger.debug("Unable to delete document for signal: {}"

--- a/rethinkdb_delete_block.py
+++ b/rethinkdb_delete_block.py
@@ -38,8 +38,10 @@ class RethinkDBDelete(EnrichSignals, RethinkDBBase):
             # this will return the typical deleted, errors, unchanges, etc.
             # as well as changes. If the delete was successful, 'new_val' will
             # be none in changes.
+
+            # can't just run .get(), need to check if primary key is only filter condition
             results = rdb.db(self.database_name()).table(self.table()).\
-                get(self.filter(signal)["id"]).delete(return_changes=True).\
+                filter(self.filter(signal)).delete(return_changes=True).\
                 run(conn)
 
         if results["deleted"] == 0:

--- a/rethinkdb_delete_block.py
+++ b/rethinkdb_delete_block.py
@@ -44,8 +44,6 @@ class RethinkDBDelete(EnrichSignals, RethinkDBBase):
                 config()
             primary_key = [table_config["primary_key"]]
             filter_condition = self.filter(signal)
-            print('primary_key = ', primary_key)
-            print('filter_condition = ', filter_condition)
 
             # Check if filter condition is only primary key, if so, use
             # .get rather than .filter for better performance

--- a/rethinkdb_delete_block.py
+++ b/rethinkdb_delete_block.py
@@ -42,12 +42,14 @@ class RethinkDBDelete(EnrichSignals, RethinkDBBase):
             # Query table configuration to get primary key
             table_config = rdb.db(self.database_name()).table(self.table()).\
                 config()
-            primary_key = table_config["primary_key"]
+            primary_key = [table_config["primary_key"]]
             filter_condition = self.filter(signal)
+            print('primary_key = ', primary_key)
+            print('filter_condition = ', filter_condition)
 
             # Check if filter condition is only primary key, if so, use
             # .get rather than .filter for better performance
-            if list(filter_condition.keys()) == list(primary_key):
+            if list(filter_condition.keys()) == primary_key:
                 results = rdb.db(self.database_name()).table(self.table()). \
                     get(filter_condition).delete(return_changes=True). \
                     run(conn)

--- a/rethinkdb_filter_block.py
+++ b/rethinkdb_filter_block.py
@@ -53,11 +53,10 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
             if list(filter_condition.keys()) == primary_key:
                 cursor = rdb.db(self.database_name()).table(self.table()).\
                     get(filter_condition).run(conn)
-                results = list(cursor)
             else:
                 cursor = rdb.db(self.database_name()).table(self.table()).\
                     filter(self.filter(signal)).run(conn)
-                results = list(cursor)
+            results = list(cursor)
         self.logger.debug(
             "Querying using filter {} return results {}".format(
                 self.filter(signal), results))

--- a/rethinkdb_filter_block.py
+++ b/rethinkdb_filter_block.py
@@ -45,7 +45,7 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
             # Query table configuration to get primary key
             table_config = rdb.db(self.database_name()).table(self.table()).\
                 config()
-            primary_key = [table_config["primary_key"]]
+            primary_key = table_config["primary_key"]
             filter_condition = self.filter(signal)
 
             # Check if filter condition is only primary key, if so, use

--- a/rethinkdb_filter_block.py
+++ b/rethinkdb_filter_block.py
@@ -45,12 +45,12 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
             # Query table configuration to get primary key
             table_config = rdb.db(self.database_name()).table(self.table()).\
                 config()
-            primary_key = table_config["primary_key"]
+            primary_key = [table_config["primary_key"]]
             filter_condition = self.filter(signal)
 
             # Check if filter condition is only primary key, if so, use
             # .get rather than .filter for better performance
-            if list(filter_condition.keys()) == list(primary_key):
+            if list(filter_condition.keys()) == primary_key:
                 cursor = rdb.db(self.database_name()).table(self.table()).\
                     get(filter_condition).run(conn)
                 results = list(cursor)
@@ -58,7 +58,6 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
                 cursor = rdb.db(self.database_name()).table(self.table()).\
                     filter(self.filter(signal)).run(conn)
                 results = list(cursor)
-            cursor.close()
         self.logger.debug(
             "Querying using filter {} return results {}".format(
                 self.filter(signal), results))

--- a/rethinkdb_update_block.py
+++ b/rethinkdb_update_block.py
@@ -17,7 +17,7 @@ class RethinkDBUpdate(EnrichSignals, RethinkDBBase):
     table = StringProperty(title="Table to update", default='test',
                            allow_none=False)
     filter = Property(title='Filter dictionary',
-                      default='{{ {"id": $id} }}',
+                      default='{{ $.to_dict() }}',
                       allow_none=False)
     object = Property(title='Dictionary data to update',
                       default='{{ $.to_dict() }}',
@@ -49,12 +49,12 @@ class RethinkDBUpdate(EnrichSignals, RethinkDBBase):
             # Query table configuration to get primary key
             table_config = rdb.db(self.database_name()).table(self.table()).\
                 config()
-            primary_key = table_config["primary_key"]
+            primary_key = [table_config["primary_key"]]
             filter_condition = self.filter(signal)
 
             # Check if filter condition is only primary key, if so, use
             # .get rather than .filter for better performance
-            if list(filter_condition.keys()) == list(primary_key):
+            if list(filter_condition.keys()) == primary_key:
                 result = rdb.db(self.database_name()).table(self.table()).\
                     get(filter_condition).update(data).run(conn)
             else:

--- a/rethinkdb_update_block.py
+++ b/rethinkdb_update_block.py
@@ -46,7 +46,7 @@ class RethinkDBUpdate(EnrichSignals, RethinkDBBase):
                 db=self.database_name(),
                 timeout=self.connect_timeout().total_seconds()) as conn:
             result = rdb.db(self.database_name()).table(self.table()).\
-                filter(self.filter(signal)).update(data).run(conn)
+                get(self.filter(signal)["id"]).update(data).run(conn)
         self.logger.debug("Sent update request, result: {}".format(result))
         if result['errors'] > 0:
             # only first error is collected

--- a/tests/test_rethinkdb_block.py
+++ b/tests/test_rethinkdb_block.py
@@ -16,7 +16,7 @@ class TestRethinkDBUpdateBlock(NIOBlockTestCase):
         blk.update_table = MagicMock(return_value={'result': 1})
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
-            mock_rdb.db.return_value.table.return_value.filter.return_value.\
+            mock_rdb.db.return_value.table.return_value.get.return_value.\
                 update.return_value.run.return_value = {"errors": 0}
             blk.process_signals([Signal({'id': 1, 'test': 1})])
         blk.stop()
@@ -71,7 +71,7 @@ class TestRethinkDBDeleteBlock(NIOBlockTestCase):
 
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
-            mock_rdb.db.return_value.table.return_value.filter.return_value.\
+            mock_rdb.db.return_value.table.return_value.get.return_value.\
                 delete.return_value.run.return_value = {"errors": 0,
                                                         "changes": {},
                                                         "deleted": 1}

--- a/tests/test_rethinkdb_block.py
+++ b/tests/test_rethinkdb_block.py
@@ -22,7 +22,7 @@ class TestRethinkDBUpdateBlock(NIOBlockTestCase):
         with patch(blk.__module__ + '.rdb') as mock_rdb:
             mock_rdb.db.return_value.table.return_value.\
                 config.return_value = self.table_config
-            mock_rdb.db.return_value.table.return_value.get.return_value.\
+            mock_rdb.db.return_value.table.return_value.filter.return_value.\
                 update.return_value.run.return_value = {"errors": 0}
             blk.process_signals([Signal({'id': 1, 'test': 1})])
         blk.stop()
@@ -83,8 +83,8 @@ class TestRethinkDBDeleteBlock(NIOBlockTestCase):
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
             mock_rdb.db.return_value.table.return_value.\
-                config.side_effect = self.table_config
-            mock_rdb.db.return_value.table.return_value.filter.return_value.\
+                config.return_value = self.table_config
+            mock_rdb.db.return_value.table.return_value.filter.return_value. \
                 delete.return_value.run.return_value = {"errors": 0,
                                                         "changes": {},
                                                         "deleted": 1}


### PR DESCRIPTION
Switch delete & update blocks to use .get with the ID in the signal.