### PR TITLE
Possible bug in _filter

### DIFF
--- a/rethinkdb_filter_block.py
+++ b/rethinkdb_filter_block.py
@@ -44,7 +44,7 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
 
             # Query table configuration to get primary key
             table_config = rdb.db(self.database_name()).table(self.table()).\
-                config()
+                config().run(conn)
             primary_key = [table_config["primary_key"]]
             filter_condition = self.filter(signal)
 
@@ -55,7 +55,7 @@ class RethinkDBFilter(EnrichSignals, RethinkDBBase):
                     get(filter_condition).run(conn)
             else:
                 cursor = rdb.db(self.database_name()).table(self.table()).\
-                    filter(self.filter(signal)).run(conn)
+                    filter(filter_condition).run(conn)
             results = list(cursor)
         self.logger.debug(
             "Querying using filter {} return results {}".format(

--- a/tests/test_rethinkdb_block.py
+++ b/tests/test_rethinkdb_block.py
@@ -164,7 +164,7 @@ class TestRethinkDBFilterBlock(NIOBlockTestCase):
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
             mock_rdb.db.return_value.table.return_value.\
-                config.return_value = self.table_config
+                config.return_value.run.return_value = self.table_config
             mock_rdb.db.return_value.table.return_value.filter.return_value.\
                 run.return_value = [{"id": 8, 'test': 7, 'test1': 7},
                                     {'id': 8, 'test': 7, 'test2': 6},
@@ -189,7 +189,7 @@ class TestRethinkDBFilterBlock(NIOBlockTestCase):
         blk.start()
         with patch(blk.__module__ + '.rdb') as mock_rdb:
             mock_rdb.db.return_value.table.return_value.\
-                config.return_value = self.table_config
+                config.return_value.run.return_value = self.table_config
             mock_rdb.db.return_value.table.return_value.get.return_value.\
                 run.return_value = [{"id": 8, 'test': 7, 'test1': 7},
                                     {'id': 8, 'test': 7, 'test2': 6},


### PR DESCRIPTION
Add `.run(conn)` to end of `table_config` query to get results. (I was getting issues before I added this).
Use `filter_conditions` variable in else statement rather than repeating `self.filter(signal)`.

Add `.run.return_value` to mock table_config variables in tests.
All tests pass with this change.